### PR TITLE
Updated the pom and its dependencies for Spring etc. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,12 @@
 
     <properties>
         <icu4j.version>51.1</icu4j.version>
-        <spring.version>3.1.4.RELEASE</spring.version>
+        <spring.version>4.1.4.RELEASE</spring.version>
         <resource-server.version>1.0.42</resource-server.version>
         <httpclient.version>4.2.5</httpclient.version>
         <antisamy.version>1.5.2</antisamy.version>
+        <junit.version>4.12</junit.version>
+        <servlet-api.version>3.0.1</servlet-api.version>
         
         <!-- The JDBC Driver used by the portlet -->
         <jdbc.groupId>org.hsqldb</jdbc.groupId>
@@ -155,15 +157,15 @@
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${servlet-api.version}</version>
                 <type>jar</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8.2</version>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -173,25 +175,34 @@
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-core-asl</artifactId>
-                <version>1.6.2</version>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.3.0</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>1.6.2</version>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.3.0</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate</artifactId>
-                <version>3.2.3.ga</version>
-                <exclusions>
-                    <exclusion>
-                          <groupId>net.sf.ehcache</groupId>
-                          <artifactId>ehcache</artifactId>
-                    </exclusion>
-                </exclusions>
+				<groupId>xerces</groupId>
+				<artifactId>xercesImpl</artifactId>
+				<version>2.11.0</version>
+            </dependency>
+            <dependency>
+				<groupId>javassist</groupId>
+				<artifactId>javassist</artifactId>
+				<version>3.12.1.GA</version>
+			</dependency>
+            <dependency>
+			    <groupId>org.hibernate</groupId>
+			    <artifactId>hibernate-core</artifactId>
+			    <version>3.6.10.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>1.7.10</version>
             </dependency>
             <dependency>
                 <groupId>org.jasig.resourceserver</groupId>
@@ -286,14 +297,14 @@
     			</exclusions>
             </dependency>
             <dependency>
-                <groupId>rome</groupId>
+                <groupId>com.rometools</groupId>
                 <artifactId>rome</artifactId>
-                <version>1.0</version>
+                <version>1.5.0</version>
             </dependency>
             <dependency>
-                <groupId>rome</groupId>
-                <artifactId>modules</artifactId>
-                <version>0.3.2</version>
+                <groupId>com.rometools</groupId>
+                <artifactId>rome-modules</artifactId>
+                <version>1.5.0</version>
             </dependency>
             <dependency>
                 <groupId>taglibs</groupId>
@@ -341,7 +352,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -353,16 +364,24 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate</artifactId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jasig.resourceserver</groupId>
@@ -418,12 +437,12 @@
 			<artifactId>antisamy</artifactId>
         </dependency>
         <dependency>
-            <groupId>rome</groupId>
+            <groupId>com.rometools</groupId>
             <artifactId>rome</artifactId>
         </dependency>
         <dependency>
-            <groupId>rome</groupId>
-            <artifactId>modules</artifactId>
+            <groupId>com.rometools</groupId>
+            <artifactId>rome-modules</artifactId>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>
@@ -505,8 +524,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <icu4j.version>51.1</icu4j.version>
         <spring.version>4.1.4.RELEASE</spring.version>
         <resource-server.version>1.0.42</resource-server.version>
-        <httpclient.version>4.2.5</httpclient.version>
+        <httpclient.version>4.4</httpclient.version>
         <antisamy.version>1.5.2</antisamy.version>
         <junit.version>4.12</junit.version>
         <servlet-api.version>3.0.1</servlet-api.version>
@@ -119,6 +119,10 @@
                     <exclusion>
                         <groupId>rhino</groupId>
                         <artifactId>js</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jdom</groupId>
+                        <artifactId>jdom</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapter.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapter.java
@@ -54,7 +54,7 @@ import org.jasig.portlet.newsreader.processor.RomeNewsProcessorImpl;
 import org.owasp.validator.html.PolicyException;
 import org.owasp.validator.html.ScanException;
 
-import com.sun.syndication.io.FeedException;
+import com.rometools.rome.io.FeedException;;
 
 
 /**

--- a/src/main/java/org/jasig/portlet/newsreader/model/NewsFeedItem.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/NewsFeedItem.java
@@ -21,7 +21,7 @@ package org.jasig.portlet.newsreader.model;
 
 import java.util.List;
 
-import com.sun.syndication.feed.synd.SyndPerson;
+import com.rometools.rome.feed.synd.SyndPerson;;
 
 /**
  * 

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/EmptyView.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/EmptyView.java
@@ -26,10 +26,10 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializerFactory;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.BindingResult;

--- a/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImpl.java
+++ b/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImpl.java
@@ -38,17 +38,17 @@ import org.owasp.validator.html.PolicyException;
 import org.owasp.validator.html.ScanException;
 import org.springframework.core.io.Resource;
 
-import com.sun.syndication.feed.module.Module;
-import com.sun.syndication.feed.module.mediarss.MediaEntryModule;
-import com.sun.syndication.feed.module.mediarss.types.MediaContent;
-import com.sun.syndication.feed.module.mediarss.types.MediaGroup;
-import com.sun.syndication.feed.synd.SyndContent;
-import com.sun.syndication.feed.synd.SyndEnclosure;
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.io.FeedException;
-import com.sun.syndication.io.SyndFeedInput;
-import com.sun.syndication.io.XmlReader;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.modules.mediarss.MediaEntryModule;
+import com.rometools.modules.mediarss.types.MediaContent;
+import com.rometools.modules.mediarss.types.MediaGroup;
+import com.rometools.rome.feed.synd.SyndContent;
+import com.rometools.rome.feed.synd.SyndEnclosure;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.FeedException;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
 
 public class RomeNewsProcessorImpl {
     

--- a/src/main/java/org/jasig/portlet/newsreader/spring/LazyInitByDefaultBeanDefinitionDocumentReader.java
+++ b/src/main/java/org/jasig/portlet/newsreader/spring/LazyInitByDefaultBeanDefinitionDocumentReader.java
@@ -33,8 +33,8 @@ import org.w3c.dom.Element;
  */
 public class LazyInitByDefaultBeanDefinitionDocumentReader extends DefaultBeanDefinitionDocumentReader {
     @Override
-    protected BeanDefinitionParserDelegate createHelper(XmlReaderContext readerContext, Element root, BeanDefinitionParserDelegate parentDelegate) {
+    protected BeanDefinitionParserDelegate createDelegate(XmlReaderContext readerContext, Element root, BeanDefinitionParserDelegate parentDelegate) {
         root.setAttribute(BeanDefinitionParserDelegate.DEFAULT_LAZY_INIT_ATTRIBUTE, "true");
-        return super.createHelper(readerContext, root, parentDelegate);
+        return super.createDelegate(readerContext, root, parentDelegate);
     }
 }

--- a/src/main/webapp/WEB-INF/context/views.xml
+++ b/src/main/webapp/WEB-INF/context/views.xml
@@ -27,7 +27,7 @@
 
     <!-- JSON data view -->
     <bean name="json" 
-        class="org.springframework.web.servlet.view.json.MappingJacksonJsonView"
+        class="org.springframework.web.servlet.view.json.MappingJackson2JsonView"
         p:disableCaching="false"/>
 
     <!-- Empty view -->

--- a/src/test/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImplTest.java
+++ b/src/test/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImplTest.java
@@ -37,7 +37,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.sun.syndication.io.FeedException;
+import com.rometools.rome.io.FeedException;;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/jasig/portlet/newsreader/processor/romeProcessorTestContext.xml")


### PR DESCRIPTION
Reference: https://github.com/spring-projects/spring-framework/wiki/Migrating-from-earlier-versions-of-the-spring-framework

Did not update:
* ehcache (from resource-server-utils)
* groovy (from cernunnous)

Update the pom and dependencies for Spring. Impacted code was updated to match changes in package references as needed. Now at the following revisions:

Spring to 4.1.4
Junit to 4.12
Servlet-api to 3.0.1
httpclient to 4.4
jackson to 2.3.0
xerces to 2.11.0
javassist to 3.12.1.GA
hibernate to 3.6.10.Final
slf4j to 1.7.10
rome to 1.5.0
compiler (java) to 1.7