### PR TITLE
MMFS-644 changed handlebars code around.

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/scripts.jsp
+++ b/src/main/webapp/WEB-INF/jsp/scripts.jsp
@@ -18,10 +18,19 @@
     under the License.
 
 --%>
+
+<%--<script type="text/javascript">
+<rs:compressJs>
+    $.widget.bridge('uibutton', $.ui.button);
+    $.widget.bridge('uitooltip', $.ui.uitooltip);
+</rs:compressJs>
+</script>--%>
+    
 <rs:aggregatedResources path="skin${ usePortalJsLibs ? '-shared' : '' }.xml"/>
 
 <script type="text/javascript"><rs:compressJs>
     var ${n} = ${n} || {};
+    
     <c:choose>
         <c:when test="${!usePortalJsLibs}">
             ${n}.jQuery = jQuery.noConflict(true);

--- a/src/main/webapp/WEB-INF/jsp/viewNews.jsp
+++ b/src/main/webapp/WEB-INF/jsp/viewNews.jsp
@@ -90,7 +90,7 @@
                         <h3 class="title">{{title}}</h3>
                     </div>
                 </div>
-                <ul class="news-stories feed">
+                <ul class="news-stories feed list-unstyled">
                 {{{news_stories entries}}}
                 </ul>
         </script>
@@ -110,16 +110,18 @@
                         <h3 class="title">{{title}}</h3>
                     </div>
                 </div>
-                <div class="news-stories feed">
+                <ul class="news-stories feed">
                     {{{news_stories entries}}}
-                </div>
+                </ul>
         </script>
         <script type="text/template" id="${n}news-story-template">
             {{#each this}}
-                <h3>
-                    <a href="{{link}}" ${ newWindow ? "target=\"_blank\"" : "" }>{{title}}</a>
-                </h3>
-                <p>{{description}}</p>
+                <li>
+					<h3>
+						<a href="{{link}}" ${ newWindow ? "target=\"_blank\"" : "" }>{{title}}</a>
+					</h3>
+					<p>{{description}}</p>
+				</li>
             {{/each}}
         </script>
 


### PR DESCRIPTION
Hello,

This code change fixes the following test case:

# Steps:
1. Login to the My Manchester system as a Student
2. On the Home tab, click on the Edit News Feed link on the My News portlet
3. Change the feed to display a list with summary text
4. Save the changes and return to the dashboard

# Expected:
The portlet now shows summary text for each feed item - the behaviour is the same as the list without summary view

# Actual:
The list no longer has a scrollable view and does not automatically refresh the feed when the end of the list is reached. The view can extend to any length depending on the content within the feed.