### PR TITLE
Added missing unique constraint to news set. Protect against attempts…

### DIFF
--- a/src/main/java/org/jasig/portlet/newsreader/service/SharedNewsSetServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/SharedNewsSetServiceImpl.java
@@ -49,13 +49,16 @@ public class SharedNewsSetServiceImpl implements NewsSetResolvingService {
 		    userId = "guest";
 		}
 		
-		NewsSet set = newsStore.getNewsSet(userId, fname);
-		if (set == null) {
-			log.debug("No existing set found, creating and saving new set.");
-	        set = new NewsSet();
-	        set.setUserId(userId);
-	        set.setName(fname);
-	        newsStore.storeNewsSet(set);
+		NewsSet set;
+		synchronized (newsStore) {
+			set = newsStore.getNewsSet(userId, fname);
+			if (set == null) {
+				log.debug("No existing set found for "+userId+", creating and saving new set.");
+		        set = new NewsSet();
+		        set.setUserId(userId);
+		        set.setName(fname);
+		        newsStore.storeNewsSet(set);
+			}	
 		}
 		
 		// Persistent set is now loaded but may still need re-initalising since last use.

--- a/src/main/resources/hibernate-mappings/NewsSet.hbm.xml
+++ b/src/main/resources/hibernate-mappings/NewsSet.hbm.xml
@@ -31,22 +31,24 @@
             <generator class="native"/>
         </id>
         
-        <!-- display name -->
-        <property name="name" type="string">
-            <column name="NEWS_NAME" length="100"/>
-        </property>
-
-        <!-- user id --> 
-        <property name="userId" type="string">
-            <column name="USER_ID" length="50"/>
-        </property>
+        <properties name="user_setname_unique_index" unique="true">
+	        <!-- new set name -->
+	        <property name="name" type="string" not-null="true">
+	            <column name="NEWS_NAME" length="100"/>
+	        </property>
+	
+	        <!-- user id --> 
+	        <property name="userId" type="string" not-null="true">
+	            <column name="USER_ID" length="50"/>
+	        </property>
+	    </properties>
 
         <set name="newsConfigurations" inverse="true" cascade="all, delete-orphan">
             <key column="SET_ID"/>
             <one-to-many
                 class="org.jasig.portlet.newsreader.NewsConfiguration"/>
         </set>
-        
+		
     </class>
     
 </hibernate-mapping>


### PR DESCRIPTION
… to violate this constraint by synchronizing the creation process

I went with the least changes approach here. Alternatively synchronizing on something user specific could have been the way to go, but obviously String userId or PortletSession are not suitable.