### PR TITLE
Enhance the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-
+# Apereo News Reader Portlet
 
 The original version of NewsReaderPortlet was written by Anthony Colebourne of University of Manchester.
 and that portlet was heavily based upon the CalendarPortlet written by Jen Bourey of Yale University
 (with permission).
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Apereo News Reader Portlet
 
-The original version of NewsReaderPortlet was written by Anthony Colebourne of University of Manchester.
-and that portlet was heavily based upon the CalendarPortlet written by Jen Bourey of Yale University
+The original version of NewsReaderPortlet [was written by][NewsReaderPortlet contributors] [Anthony Colebourne][] of University of Manchester and that portlet was heavily based upon the [CalendarPortlet][] written by [Jen Bourey][] of Yale University
 (with permission).
+
+[Anthony Colebourne]: https://github.com/acolebourne
+[Jen Bourey]: https://github.com/bourey
+
+[CalendarPortlet]: https://github.com/Jasig/CalendarPortlet
+
+[NewsReaderPortlet contributors]: https://github.com/Jasig/NewsReaderPortlet/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Apereo News Reader Portlet
 
+This Java Portlet is a [Sponsored Portlet][] in the uPortal project.
+
+See also [documentation in the external wiki][NewsReaderPortlet in Confluence].
+
 The original version of NewsReaderPortlet [was written by][NewsReaderPortlet contributors] [Anthony Colebourne][] of University of Manchester and that portlet was heavily based upon the [CalendarPortlet][] written by [Jen Bourey][] of Yale University
 (with permission).
 
 [Anthony Colebourne]: https://github.com/acolebourne
 [Jen Bourey]: https://github.com/bourey
 
+[Sponsored Portlet]: https://wiki.jasig.org/display/PLT/Jasig+Sponsored+Portlets
+[NewsReaderPortlet in Confluence]: https://wiki.jasig.org/display/PLT/NewsReaderPortlet
 [CalendarPortlet]: https://github.com/Jasig/CalendarPortlet
 
 [NewsReaderPortlet contributors]: https://github.com/Jasig/NewsReaderPortlet/graphs/contributors


### PR DESCRIPTION

* Convert the `README` to Markdown 
* add hyperlinks
* note sponsored-portlet-ness
* link existing Confluence wiki documentation.