### PR TITLE
docs(readme): add maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Apereo News Reader Portlet
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/NewsReaderPortlet/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/NewsReaderPortlet)
 [![Linux Build Status](https://travis-ci.org/Jasig/NewsReaderPortlet.svg?branch=master)](https://travis-ci.org/Jasig/NewsReaderPortlet)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/2ch9x7y3if4sq8eh/branch/master?svg=true)](https://ci.appveyor.com/project/ChristianMurphy/newsreaderportlet/branch/master)
 


### PR DESCRIPTION
Give at-a-glance knowledge of:
* latest version number
* that this is available from maven central
* link to documentation on inclusion for maven, gradle, etc