### PR TITLE
chore(deps): update taglibs standard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,9 +426,9 @@
                 <version>1.5.1</version>
             </dependency>
             <dependency>
-                <groupId>taglibs</groupId>
-                <artifactId>standard</artifactId>
-                <version>1.1.2</version>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-impl</artifactId>
+                <version>1.2.5</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -598,8 +598,8 @@
             <artifactId>rome-modules</artifactId>
         </dependency>
         <dependency>
-            <groupId>taglibs</groupId>
-            <artifactId>standard</artifactId>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
NOTE: Repository is now hosted out of org.apache.taglibs