### PR TITLE
chore: bump uportal-portlet-parent 47 → 48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>47</version>
+        <version>48</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Summary

Parent v48 bumps `logback-classic` 1.3.12 → 1.5.32 for security fixes.

No local changes needed beyond the parent bump — this portlet already inherits `logback-classic` from the parent.

## Compatibility

- **Java 11 baseline**: logback 1.5.x requires Java 11+. Matches this portlet's deployment target.
- **SLF4J**: unchanged 2.x binding.
- **`javax.servlet` → `jakarta.servlet`**: only affects `logback-access`, which this portlet does not use.

## Test plan
- [x] `mvn validate` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)