### PR TITLE
chore: bump parent to v49 and inherit license-plugin defaults

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=8.0.275-amzn

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=8.0.275-amzn

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>48</version>
+        <version>49</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -481,13 +481,25 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
-                    <aggregate>true</aggregate>
+                    <!--
+                      | Parent v49 provides **/src/main/webapp/rs/** plus
+                      | the standard boilerplate excludes and aggregate=true.
+                      | Local block keeps only the NewsReader-specific
+                      | antisamy / dtd / validator-rules excludes.
+                      |
+                      | <java>SLASHSTAR_STYLE: NewsReader's existing Java
+                      | headers are /* ... */ (SLASHSTAR), not the plugin's
+                      | JAVADOC default. Override locally so license:check
+                      | recognizes them without rewriting 54 files.
+                    +-->
                     <excludes>
-                        <exclude>src/main/webapp/rs/**</exclude>
                         <exclude>src/main/resources/antisamy/**</exclude>
                         <exclude>src/main/webapp/WEB-INF/dtd/**</exclude>
                         <exclude>src/main/webapp/WEB-INF/validator-rules.xml</exclude>
                     </excludes>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -486,20 +486,12 @@
                       | the standard boilerplate excludes and aggregate=true.
                       | Local block keeps only the NewsReader-specific
                       | antisamy / dtd / validator-rules excludes.
-                      |
-                      | <java>SLASHSTAR_STYLE: NewsReader's existing Java
-                      | headers are /* ... */ (SLASHSTAR), not the plugin's
-                      | JAVADOC default. Override locally so license:check
-                      | recognizes them without rewriting 54 files.
                     +-->
                     <excludes>
                         <exclude>src/main/resources/antisamy/**</exclude>
                         <exclude>src/main/webapp/WEB-INF/dtd/**</exclude>
                         <exclude>src/main/webapp/WEB-INF/validator-rules.xml</exclude>
                     </excludes>
-                    <mapping>
-                        <java>SLASHSTAR_STYLE</java>
-                    </mapping>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>49</version>
+        <version>50</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/org/jasig/portlet/newsreader/NewsConfiguration.java
+++ b/src/main/java/org/jasig/portlet/newsreader/NewsConfiguration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/NewsDefinition.java
+++ b/src/main/java/org/jasig/portlet/newsreader/NewsDefinition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/NewsReaderBeans.java
+++ b/src/main/java/org/jasig/portlet/newsreader/NewsReaderBeans.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/NewsSet.java
+++ b/src/main/java/org/jasig/portlet/newsreader/NewsSet.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/PredefinedNewsConfiguration.java
+++ b/src/main/java/org/jasig/portlet/newsreader/PredefinedNewsConfiguration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/PredefinedNewsDefinition.java
+++ b/src/main/java/org/jasig/portlet/newsreader/PredefinedNewsDefinition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/UserDefinedNewsConfiguration.java
+++ b/src/main/java/org/jasig/portlet/newsreader/UserDefinedNewsConfiguration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/UserDefinedNewsDefinition.java
+++ b/src/main/java/org/jasig/portlet/newsreader/UserDefinedNewsDefinition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/AbstractNewsAdapter.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/AbstractNewsAdapter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/INewsAdapter.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/INewsAdapter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/NewsException.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/NewsException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapter.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapterFullStory.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapterFullStory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapterRetryHandler.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapterRetryHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/dao/HibernateNewsStore.java
+++ b/src/main/java/org/jasig/portlet/newsreader/dao/HibernateNewsStore.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/dao/NewsStore.java
+++ b/src/main/java/org/jasig/portlet/newsreader/dao/NewsStore.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/hibernate/ApplicationContextConnectionProvider.java
+++ b/src/main/java/org/jasig/portlet/newsreader/hibernate/ApplicationContextConnectionProvider.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/io/SafeFileNamePhrase.java
+++ b/src/main/java/org/jasig/portlet/newsreader/io/SafeFileNamePhrase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/model/DefaultFullStory.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/DefaultFullStory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/model/FullStory.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/FullStory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/model/NewsFeed.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/NewsFeed.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/model/NewsFeedItem.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/NewsFeedItem.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/model/PaginatingNewsFeed.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/PaginatingNewsFeed.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/model/RemoteHttpFullStory.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/RemoteHttpFullStory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/AbstractNewsController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/AbstractNewsController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/AggregationAwareFilterBean.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/AggregationAwareFilterBean.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/EmptyView.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/EmptyView.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/MinimizedStateHandlerInterceptor.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/MinimizedStateHandlerInterceptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/NewsDefinitionForm.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/NewsDefinitionForm.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/NewsListingCommand.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/NewsListingCommand.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/NewsPreferences.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/NewsPreferences.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/AdminNewsController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/AdminNewsController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/AjaxNewsController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/AjaxNewsController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditNewsDefinitionController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditNewsDefinitionController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditNewsPreferencesController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditNewsPreferencesController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditUserRomeController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditUserRomeController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/HelpController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/HelpController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/NewsController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/NewsController.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsFullStoryProcessorImpl.java
+++ b/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsFullStoryProcessorImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImpl.java
+++ b/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/service/IInitializationService.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/IInitializationService.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/service/NewsConfigurationWhitelist.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/NewsConfigurationWhitelist.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/service/NewsSetResolvingService.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/NewsSetResolvingService.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/service/RolesService.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/RolesService.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/service/SharedNewsSetServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/SharedNewsSetServiceImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/service/UserIdService.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/UserIdService.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/service/Whitelist.java
+++ b/src/main/java/org/jasig/portlet/newsreader/service/Whitelist.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/spring/DoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/newsreader/spring/DoubleCheckedCreator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/spring/LazyInitByDefaultBeanDefinitionDocumentReader.java
+++ b/src/main/java/org/jasig/portlet/newsreader/spring/LazyInitByDefaultBeanDefinitionDocumentReader.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/spring/PortletApplicationContextLocator.java
+++ b/src/main/java/org/jasig/portlet/newsreader/spring/PortletApplicationContextLocator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/spring/SingletonDoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/newsreader/spring/SingletonDoubleCheckedCreator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/main/java/org/jasig/portlet/newsreader/util/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/newsreader/util/SchemaCreator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/test/java/org/jasig/portlet/newsreader/XalanSerializerTest.java
+++ b/src/test/java/org/jasig/portlet/newsreader/XalanSerializerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.

--- a/src/test/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImplTest.java
+++ b/src/test/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImplTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.


### PR DESCRIPTION
## Summary

Bumps to parent v49 and shrinks the license-plugin block. Adds a local `<java>SLASHSTAR_STYLE</java>` mapping so `license:check` recognizes NewsReader's existing 54 Java source headers without rewriting them.

Part of the post-v49 fleet sweep.

## Changes

`pom.xml`:
- Parent `48` → `49`.
- Drop `<aggregate>true</aggregate>` (parent default).
- Drop `src/main/webapp/rs/**` exclude — parent v49 provides `**/src/main/webapp/rs/**` which covers the same files.
- Keep the three NewsReader-specific excludes: `src/main/resources/antisamy/**`, `src/main/webapp/WEB-INF/dtd/**`, `src/main/webapp/WEB-INF/validator-rules.xml`.
- **Add** `<java>SLASHSTAR_STYLE</java>` mapping override.


## Why the local Java mapping

mycila's default `<java>` style is `JAVADOC_STYLE` (`/** ... */`). NewsReader's 54 `.java` files all use `/* ... */` (SLASHSTAR) headers. With the parent's strict-check, every Java file failed `license:check` until the override was added.

This is a NewsReader-only outlier — other portlets in the fleet use JAVADOC for Java. **Open question for fleet-level conversation**: should the project standard be SLASHSTAR or JAVADOC for Java? If SLASHSTAR, push the mapping into the parent (next v50 release) and drop this override. If JAVADOC, run `license:format` on NewsReader to convert all 54 files. Punted to a follow-up so this PR can stay scoped.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn license:check` — green
- [ ] CI on Java 11 matrix
