### PR TITLE
chore: bump parent v50 → v51 and migrate commons-lang → commons-lang3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,7 +19,8 @@ This project includes:
   ant-launcher under Apache License, Version 2.0
   AntLR under BSD License
   Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpComponents Core HTTP/1.1 under Apache License, Version 2.0
   Apache HttpComponents Core HTTP/2 under Apache License, Version 2.0
@@ -30,6 +31,7 @@ This project includes:
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
   Cernunnos - Core under Apache 2
+  Checker Qual under The MIT License
   Commons DBCP under The Apache Software License, Version 2.0
   Commons FileUpload under The Apache Software License, Version 2.0
   Commons IO under The Apache Software License, Version 2.0
@@ -41,16 +43,22 @@ This project includes:
   dom4j under BSD License
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
+  error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   ezmorph under The Apache Software License, Version 2.0
+  FindBugs-jsr305 under The Apache Software License, Version 2.0
   Groovy under Apache License, Version 2.0
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
+  Guava ListenableFuture only under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest Core under New BSD License
   Hibernate Commons Annotations under GNU LESSER GENERAL PUBLIC LICENSE
   Hibernate Core under GNU Lesser General Public License
-  Hibernate Ehcache Integration under GNU Lesser General Public License
+  hibernate-ehcache under LGPL, v2.1
   HtmlUnit NekoHtml under Apache License, Version 2.0
   HyperSQL Database under HSQLDB License, a BSD open source license
-  ICU4J under Unicode/ICU License
+  icu4j under MIT License
+  J2ObjC Annotations under Apache License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
@@ -68,18 +76,17 @@ This project includes:
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   jaxen under Apache style license
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
+  JCL 1.2 implemented over SLF4J under Apache-2.0
   JDOM under Similar to Apache License but with the acknowledgment clause removed
   JLine under BSD
   JPA 2.0 API under Sun Binary Code License
   json-lib under Apache License, Version 2.0
   jstl under Commons Development and Distribution License, Version 1.0
-  JUL to SLF4J bridge under MIT License
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logging under The Apache Software License, Version 2.0
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   Mockito under The MIT License
   mockito-core under The MIT License
   Neko HTML under The Apache Software License, Version 2.0
@@ -102,7 +109,7 @@ This project includes:
   rome-modules under The Apache Software License, Version 2.0
   rome-utils under The Apache Software License, Version 2.0
   serializer under Apache License, Version 2.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
   Spring Context under Apache License, Version 2.0
@@ -122,7 +129,7 @@ This project includes:
   uPortal under The Apache License, Version 2.0
   xalan under Apache License, Version 2.0
   Xerces2-j under The Apache Software License, Version 2.0
-  XML Commons External Components XML APIs under The Apache Software License, Version 2.0 or The SAX License or The W3C License
+  XML Commons External Components XML APIs under The Apache Software License, Version 2.0
   XML Commons External Components XML APIs Extensions under The Apache Software License, Version 2.0
   xmlParserAPIs under Apache License, Version 2.0
   xom under LGPL

--- a/licenses/license-mappings.xml
+++ b/licenses/license-mappings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<license-lookup xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd">
+
+    <!--
+      Local license-mapping overrides for artifacts not present in
+      uportal-portlet-parent's shared license-mappings.xml.
+
+      hibernate-ehcache is part of the upstream Hibernate ORM project
+      and ships under the same LGPL 2.1 license as hibernate-core and
+      hibernate-ejb3-persistence (both of which the parent maps to LGPL).
+      The "-atlassian-N" qualifier is the Atlassian-hosted patched
+      build hosted at https://packages.atlassian.com/maven/repository/public/.
+      Add the bare artifactId entry so any version (including the
+      Atlassian-hosted variants) resolves cleanly.
+    -->
+    <artifact>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-ehcache</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+
+</license-lookup>

--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,22 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Local notice-plugin override: extend the parent's license-lookup
+                 URL with a local file that supplies a mapping for hibernate-ehcache
+                 (the Atlassian-hosted variant in use here is missing from parent
+                 mappings). Drop this override once parent mappings learn about
+                 hibernate-ehcache. -->
+            <plugin>
+                <groupId>org.jasig.maven</groupId>
+                <artifactId>notice-maven-plugin</artifactId>
+                <configuration>
+                    <licenseMapping>
+                        <param>${jasig-license-lookup-url}</param>
+                        <param>file://${basedir}/licenses/license-mappings.xml</param>
+                    </licenseMapping>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>50</version>
+        <version>51</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -165,8 +165,8 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.portlet</groupId>

--- a/src/main/java/org/jasig/portlet/newsreader/NewsConfiguration.java
+++ b/src/main/java/org/jasig/portlet/newsreader/NewsConfiguration.java
@@ -18,7 +18,7 @@
  */
 package org.jasig.portlet.newsreader;
 
-import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 
 /**
  * NewsConfiguration represents a user-specific registration and configuration

--- a/src/main/java/org/jasig/portlet/newsreader/NewsDefinition.java
+++ b/src/main/java/org/jasig/portlet/newsreader/NewsDefinition.java
@@ -21,8 +21,8 @@ package org.jasig.portlet.newsreader;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.CompareToBuilder;
-import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 /**
  * NewsDefinition represents the base class for news registrations.

--- a/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapter.java
+++ b/src/main/java/org/jasig/portlet/newsreader/adapter/RomeAdapter.java
@@ -28,7 +28,7 @@ import javax.portlet.PortletRequest;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.http.HttpHost;

--- a/src/main/java/org/jasig/portlet/newsreader/model/NewsFeed.java
+++ b/src/main/java/org/jasig/portlet/newsreader/model/NewsFeed.java
@@ -22,10 +22,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * <p>NewsFeed class.</p>

--- a/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditUserRomeController.java
+++ b/src/main/java/org/jasig/portlet/newsreader/mvc/portlet/reader/EditUserRomeController.java
@@ -24,7 +24,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
 import javax.portlet.RenderResponse;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.newsreader.NewsConfiguration;
 import org.jasig.portlet.newsreader.PredefinedNewsDefinition;
 import org.jasig.portlet.newsreader.UserDefinedNewsConfiguration;

--- a/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImpl.java
+++ b/src/main/java/org/jasig/portlet/newsreader/processor/RomeNewsProcessorImpl.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.jasig.portlet.newsreader.model.NewsFeedItem;

--- a/src/main/java/org/jasig/portlet/newsreader/spring/DoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/newsreader/spring/DoubleCheckedCreator.java
@@ -22,7 +22,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jasig/portlet/newsreader/spring/SingletonDoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/newsreader/spring/SingletonDoubleCheckedCreator.java
@@ -20,8 +20,8 @@ package org.jasig.portlet.newsreader.spring;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Provides a DoubleCheckedCreator impl that tracks the singleton instance internally


### PR DESCRIPTION
Release-prep PR for NewsReaderPortlet 5.1.2, aligning with the fleet-wide v51 + lang3 wave.

Supersedes #433 (Renovate's bare parent v51 bump — would fail without the source migration here).

## Summary

Two commits:

1. **Parent v50 -> v51 + commons-lang -> commons-lang3** — parent v51 dropped legacy `commons-lang` from `dependencyManagement` (CVE-2025-48924 close-out). Source migration (8 files) is the standard package rename — `org.apache.commons.lang.*` to `org.apache.commons.lang3.*` (StringUtils + builder.* classes). lang3 is API-compatible.
2. **Add local license-mapping override + regenerate NOTICE** — `mvn notice:check` was failing on master before this branch even existed because Renovate's `hibernate-ehcache 3.6.10.Final-atlassian-4` bump (#417) introduced an artifact missing from `uportal-portlet-parent`'s shared `license-mappings.xml`. CI runs `mvn -B package` only, so `notice:check` never ran in CI, and the gap shipped silently. Adding a local `licenses/license-mappings.xml` mapping `hibernate-ehcache -> LGPL 2.1` (matches the parent's existing `hibernate-core` / `hibernate-ejb3-persistence` entries — same upstream Hibernate ORM project) and extending the notice-plugin `<licenseMapping>` config to layer it on top of the parent URL.

The earlier v49 -> v50 bump shipped via #431 and is the merge base here.

## Test plan

- [x] `mvn -B clean install` passes locally on Java 11
- [x] `mvn notice:check` passes (was failing on master before this branch)
- [x] `mvn license:check` passes
- [ ] CI green
- [ ] Post-merge: `mvn release:clean release:prepare release:perform` for 5.1.2

## Follow-up

The local `hibernate-ehcache` mapping should migrate to `uportal-portlet-parent`'s shared `licenses/license-mappings.xml` in the next parent release (v52). At that point this local override can be dropped.