### PR TITLE
fix: re-add commons-collections runtime dep for Hibernate 3.6 LRUMap

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,6 +19,7 @@ This project includes:
   ant-launcher under Apache License, Version 2.0
   AntLR under BSD License
   Apache Commons Codec under Apache License, Version 2.0
+  Apache Commons Collections under Apache License, Version 2.0
   Apache Commons Compress under Apache-2.0
   Apache Commons Lang under Apache-2.0
   Apache HttpClient under Apache License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -147,12 +147,6 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
-                <!-- cernunnos pulls json-lib:jdk15 which pulls commons-collections 3.2.2
-                     (CVE-2015-6420, banned by uportal-portlet-parent). -->
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -219,14 +213,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
-            <exclusions>
-                <!-- hibernate-core 3.6.10 pulls commons-collections 3.2.2
-                     (CVE-2015-6420, banned by uportal-portlet-parent). -->
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -443,10 +429,54 @@
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
         </dependency>
+
+        <!-- Hibernate 3.6.10 (legacy stack pinned in this portlet) calls
+             org.apache.commons.collections.map.LRUMap at runtime from
+             LocalSessionFactoryBean. uportal-portlet-parent v51 banned
+             commons-collections [3.2.1,4.0] over CVE-2015-6420 (RCE via
+             deserialization), but Hibernate's internal LRUMap usage is not
+             a deserialization vector — the CVE requires attacker-controlled
+             serialized input that this code path doesn't expose. Declare it
+             explicitly at runtime scope so the WAR bundles it; the local
+             enforcer override below allows 3.2.2 specifically. Drop both
+             once Hibernate is upgraded out of 3.6 (gated on the broader
+             Spring 6 / Jakarta migration). -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+
+            <!-- Local enforcer override: parent v51 bans
+                 commons-collections [3.2.1,4.0] over CVE-2015-6420, but
+                 Hibernate 3.6 needs LRUMap from 3.2.2 at runtime (see the
+                 commons-collections dependency block above for full context).
+                 Allow 3.2.2 specifically here. Drop once Hibernate is
+                 upgraded out of 3.6. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <includes>
+                                        <include>commons-collections:commons-collections:3.2.2</include>
+                                    </includes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
               <plugin>
                 <groupId>org.jasig.resourceserver</groupId>
                 <artifactId>resource-server-plugin</artifactId>

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,11 @@
       "matchPackageNames": ["javax.servlet:javax.servlet-api"],
       "allowedVersions": "< 5.0",
       "description": "Servlet API 5+ is in the Jakarta EE namespace and incompatible with this portlet's javax.servlet imports. Runtime is Tomcat 8.5/9 (Servlet 3.1)."
+    },
+    {
+      "matchPackageNames": ["commons-collections:commons-collections"],
+      "allowedVersions": "3.2.2",
+      "description": "Pinned to 3.2.2 specifically. Hibernate 3.6 needs LRUMap from this jar at runtime; uportal-portlet-parent v51 bans the [3.2.1,4.0] range over CVE-2015-6420 and we override that locally. The 4.x line is org.apache.commons:commons-collections4 with a different package, so it isn't a drop-in replacement. Revisit when this portlet upgrades out of Hibernate 3.6."
     }
   ]
 }


### PR DESCRIPTION
## Problem

5.1.2 (and 5.1.3, which shipped no functional changes) dropped \`commons-collections\` from the runtime classpath. The pom excluded \`commons-collections\` transitively from both \`cernunnos\` and \`hibernate-core\`, citing CVE-2015-6420 and \`uportal-portlet-parent\` v51's \`bannedDependencies\` enforcer rule.

Hibernate 3.6.10's \`LocalSessionFactoryBean\` calls \`org.apache.commons.collections.map.LRUMap\` unconditionally at \`SessionFactory\` build time, so portlet startup fails with \`NoClassDefFoundError\` on every request that touches the portlet's Spring context — \`dataInit\`, \`dataImport\`, normal portlet rendering. The bare \`mvn package\` CI never exercised the failing path so the regression shipped silently in 5.1.2 and 5.1.3.

## CVE risk assessment

CVE-2015-6420 against \`commons-collections\` 3.2.2 is a deserialization RCE that requires attacker-controlled serialized input. Hibernate's internal \`LRUMap\` usage doesn't expose that surface; the dep is on the runtime classpath but isn't reachable from any remote-attacker-controlled deserialization path in this portlet. Per-portlet override (rather than fleet-wide unbanning) is the right scope until Hibernate is upgraded out of 3.6, which is gated on the broader Spring 6 / Jakarta migration.

## Changes

- **pom.xml**:
  - Drop the now-counterproductive \`<exclusion>commons-collections</>\` blocks under \`cernunnos\` and \`hibernate-core\`.
  - Add an explicit \`<dependency>commons-collections:commons-collections:3.2.2</>\` at \`runtime\` scope with an explanatory comment naming the Hibernate 3.6 dependency on \`LRUMap\`.
  - Add a local \`maven-enforcer-plugin\` override re-allowing 3.2.2 specifically via \`bannedDependencies/<includes>\`. The parent's broader \`[3.2.1,4.0]\` ban stays intact for everything else.
- **NOTICE**: regenerated to include "Apache Commons Collections".
- **renovate.json**: pin \`commons-collections:commons-collections\` to 3.2.2 exactly. The 4.x line is the \`org.apache.commons:commons-collections4\` groupId rename with a different package, so it isn't a drop-in.

## Test plan

- [x] \`mvn -B clean install notice:check license:check\` passes locally on Java 11
- [x] Built locally as \`5.1.4-SNAPSHOT\`, deployed into uPortal-start, restarted Tomcat — \`commons-collections-3.2.2.jar\` is bundled in the WAR; no \`LRUMap\` / \`Context [/NewsReaderPortlet] startup failed\` errors in the logs
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for 5.1.4