### PR TITLE
refactor: handlebars replacement + drop resource-server-content overlay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,12 +286,6 @@
         </dependency>
         <dependency>
             <groupId>org.jasig.resourceserver</groupId>
-            <artifactId>resource-server-content</artifactId>
-            <version>${resource-server.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.jasig.resourceserver</groupId>
             <artifactId>resource-server-utils</artifactId>
             <version>${resource-server.version}</version>
             <exclusions>
@@ -529,15 +523,6 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <attachClasses>true</attachClasses>
-                    <overlays>
-                        <overlay>
-                            <groupId>org.jasig.resourceserver</groupId>
-                            <artifactId>resource-server-content</artifactId>
-                            <includes>
-                                <include>rs/famfamfam/silk/1.3/bullet_feed.png</include>
-                            </includes>
-                        </overlay>
-                    </overlays>
                 </configuration>
             </plugin>
             <!-- Plug-in to add lifecycles to support db-init, data-import, and data-export -->

--- a/src/main/webapp/WEB-INF/jsp/fullStory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/fullStory.jsp
@@ -22,15 +22,12 @@
     <link href="<c:url value="/css/newsreader.css"/>" rel="stylesheet" type="text/css" />
 <c:set var="n"><portlet:namespace/></c:set>
 <%--
-  -- Attach jQuery and Handlebars to ${n}.
-  -- Similar to scripts.js but without initializing "upnews"
+  -- Attach jQuery to ${n}. Similar to scripts.jsp but without initializing "upnews".
   --%>
 <rs:aggregatedResources path="skin.xml"/>
 <script type="text/javascript">
     var ${n} = ${n} || {};
     ${n}.jQuery = (typeof up !== 'undefined' && up.jQuery) ? up.jQuery : jQuery;
-    ${n}.Handlebars = Handlebars;
-    Handlebars.noConflict();
 </script>
 
 <div class="org-jasig-portlet-newsreader">
@@ -110,7 +107,7 @@
 
     /* Apply feed template to dropdown/tabs */
     var source = $("#${n}feed-list-template").html();
-    var template = ${n}.Handlebars.compile(source);
+    var template = upnews.compileTemplate(source);
     $("#${n} .news-feeds-container").html(template(${feeds}));
 
     if (${ feedView == 'select' }) {

--- a/src/main/webapp/WEB-INF/jsp/scripts.jsp
+++ b/src/main/webapp/WEB-INF/jsp/scripts.jsp
@@ -23,11 +23,9 @@
 <script type="text/javascript">
     var ${n} = ${n} || {};
     ${n}.jQuery = up.jQuery;
-    ${n}.Handlebars = Handlebars;
-    Handlebars.noConflict();
     ${n}.upnews = ${n}.upnews || upnews;
     if (!${n}.upnews.initialized) {
-        ${n}.upnews.init(${n}.jQuery, ${n}.Handlebars);
+        ${n}.upnews.init(${n}.jQuery);
         ${n}.upnews.initialized = true;
     }
     upnews = null;

--- a/src/main/webapp/WEB-INF/jsp/viewNews.jsp
+++ b/src/main/webapp/WEB-INF/jsp/viewNews.jsp
@@ -139,14 +139,13 @@
 <script type="text/javascript">
     ${n}.jQuery(function() {
 
-        var $, Handlebars, newsView, upnews;
+        var $, newsView, upnews;
 
         $ = ${n}.jQuery;
-        Handlebars = ${n}.Handlebars;
         upnews = ${n}.upnews;
 
-        var newsStoryTemplate = Handlebars.compile($("#${n}news-story-template").html())
-        Handlebars.registerHelper('news_stories', function(entries) {
+        var newsStoryTemplate = upnews.compileTemplate($("#${n}news-story-template").html());
+        upnews.registerHelper('news_stories', function(entries) {
             return newsStoryTemplate(entries);
         });
 
@@ -212,7 +211,7 @@
 
             },
             feedDetailView: $.extend(upnews.NewsFeedDetailView, {
-                template: Handlebars.compile($("#${n}feed-detail-template").html()),
+                template: upnews.compileTemplate($("#${n}feed-detail-template").html()),
                 postRender: adjustToolTips,
                 loader: function(id) {
                     var view = this;
@@ -243,7 +242,7 @@
             }),
             feedListView: $.extend(upnews.NewsFeedListView, {
                 $el: $("#${n} .news-feeds-container"),
-                template: Handlebars.compile($("#${n}feed-list-template").html())
+                template: upnews.compileTemplate($("#${n}feed-list-template").html())
             }),
             namespace: "${n}"
         });

--- a/src/main/webapp/less/includes/theme.less
+++ b/src/main/webapp/less/includes/theme.less
@@ -71,7 +71,7 @@ p.newsreader-pubdate {
 
             li {
                 padding-bottom:0.5em;
-                list-style-image:url('/NewsReaderPortlet/rs/famfamfam/silk/1.3/bullet_feed.png');
+                list-style-image:url('/NewsReaderPortlet/images/bullet_feed.png');
             }
         }
     }

--- a/src/main/webapp/scripts/news.js
+++ b/src/main/webapp/scripts/news.js
@@ -22,7 +22,67 @@ var upnews = {};
 
 (function() {
 
-    upnews.init = function($, Handlebars) {
+    // Tiny templating helper — supports the subset of Handlebars syntax that
+    // NewsReader templates use: {{var}} (HTML-escaped), {{{var}}} (raw),
+    // {{#each X}}…{{/each}}, {{#if X}}…{{/if}}, and {{{helperName arg}}}.
+    // Replaces the previous Handlebars 3.0.3 dependency; see
+    // https://CVE-2019-19919 / CVE-2019-20920 (prototype pollution in <4.0.14).
+    var helpers = {};
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function resolve(expr, ctx) {
+        if (expr === 'this') return ctx;
+        return ctx == null ? undefined : ctx[expr];
+    }
+
+    function renderTemplate(source, ctx) {
+        // Strip Handlebars-style comments: {{! ... }} and {{!-- ... --}}
+        source = source.replace(/\{\{!--[\s\S]*?--\}\}|\{\{![\s\S]*?\}\}/g, '');
+        // {{#each X}}...{{/each}}
+        source = source.replace(/\{\{#each\s+([^\s\}]+)\}\}([\s\S]*?)\{\{\/each\}\}/g, function (_m, expr, body) {
+            var arr = resolve(expr, ctx);
+            if (!arr) return '';
+            return Array.prototype.map.call(arr, function (item) {
+                return renderTemplate(body, item);
+            }).join('');
+        });
+        // {{#if X}}...{{/if}}
+        source = source.replace(/\{\{#if\s+([^\}]+?)\}\}([\s\S]*?)\{\{\/if\}\}/g, function (_m, expr, body) {
+            return resolve(expr.trim(), ctx) ? renderTemplate(body, ctx) : '';
+        });
+        // Helper call {{{name arg}}} — must run before plain {{{var}}}
+        source = source.replace(/\{\{\{(\w+)\s+([^\}]+)\}\}\}/g, function (_m, name, expr) {
+            return helpers[name] ? String(helpers[name](resolve(expr.trim(), ctx))) : '';
+        });
+        // Raw {{{var}}}
+        source = source.replace(/\{\{\{([^\}]+)\}\}\}/g, function (_m, expr) {
+            var v = resolve(expr.trim(), ctx);
+            return v == null ? '' : String(v);
+        });
+        // Escaped {{var}} (exclude block-tag markers)
+        source = source.replace(/\{\{([^\}#\/][^\}]*?)\}\}/g, function (_m, expr) {
+            return escapeHtml(resolve(expr.trim(), ctx));
+        });
+        return source;
+    }
+
+    upnews.compileTemplate = function (source) {
+        return function (data) { return renderTemplate(source, data); };
+    };
+
+    upnews.registerHelper = function (name, fn) {
+        helpers[name] = fn;
+    };
+
+    upnews.init = function ($) {
 
         $.fn.infiniteScroll = function(options) {
 

--- a/src/main/webapp/skin.xml
+++ b/src/main/webapp/skin.xml
@@ -21,8 +21,6 @@
 <resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
 
-    <js resource="true">/rs/handlebars/3.0.3/handlebars-v3.0.3.js</js>
-
     <js>scripts/news.js</js>
 
 </resources>


### PR DESCRIPTION
## Summary

Two commits, both part of the broader resource-server consolidation:

1. **`05ba536`** (prior) — replace bundled Handlebars 3.0.3 with a native mini-renderer.
2. **`5cee1aa`** (new) — drop the `resource-server-content` WAR overlay. The overlay was unpacking lodash 4.17.4 (4 CVEs), underscore, backbone, modernizr, normalize, and a stack of jquery-plugins into the WAR for nothing. The single file the portlet actually wanted (`bullet_feed.png`) has had a byte-identical local copy at `src/main/webapp/images/bullet_feed.png` since 2020 (verified by MD5). Switched the one CSS reference to the local path; dropped the runtime dep and the maven-war-plugin overlay-include config. WAR shrinks ~23 MB.

## Test plan

- [x] `mvn clean install -DskipTests` builds (verified locally on Java 11)
- [x] WAR contains `images/bullet_feed.png`, no `rs/famfamfam/`, no `rs/lodash/` (verified)
- [x] Visual smoke: RSS-feed list bullets render correctly (the `theme.less` change targets this) — exercise via `/p/chronicle-wired/max/render.uP` after `tomcatDeploy`