### PR TITLE
chore(deps): block renovate noise on jakarta-migration + retired-project deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
     {
       "matchPackageNames": [
         "com.sun.xml.bind:jaxb-impl",
+        "com.sun.xml.bind:jaxb-xjc",
         "jakarta.xml.bind:jakarta.xml.bind-api",
         "org.glassfish.jaxb:jaxb-runtime"
       ],
@@ -53,6 +54,27 @@
       "matchPackageNames": ["commons-collections:commons-collections"],
       "allowedVersions": "3.2.2",
       "description": "Pinned to 3.2.2 specifically. Hibernate 3.6 needs LRUMap from this jar at runtime; uportal-portlet-parent v51 bans the [3.2.1,4.0] range over CVE-2015-6420 and we override that locally. The 4.x line is org.apache.commons:commons-collections4 with a different package, so it isn't a drop-in replacement. Revisit when this portlet upgrades out of Hibernate 3.6."
+    },
+    {
+      "matchPackagePrefixes": ["org.apache.portals.pluto:"],
+      "allowedVersions": "< 3.0",
+      "description": "Apache Pluto is in the Attic; pluto-taglib 3.x and the rest of Pluto 3.x ship in the jakarta.portlet namespace, which uPortal cannot move to since the embedded Pluto container has no jakarta path. Stay on 2.1.0-M3 (the last javax.portlet release)."
+    },
+    {
+      "matchPackageNames": ["jaxen:jaxen"],
+      "allowedVersions": "< 2.0",
+      "description": "uportal-portlet-parent pins jaxen to Atlassian's 1.2.0-atlassian-2 fork (same pattern used for commons-lang and ehcache-spring-annotations). Jaxen 2.x is the mainline release and would back out of the fork-tracking convention; ignore until the fork policy is revisited."
+    },
+    {
+      "matchPackagePrefixes": ["org.junit.jupiter:", "org.junit.platform:"],
+      "matchPackageNames": ["org.junit:junit-bom"],
+      "enabled": false,
+      "description": "Tests are JUnit 4 (4.13.2 via uportal-portlet-parent) + Mockito. JUnit 5 (Jupiter) is a separate test engine; migrating would require re-annotating every @Before/@Test/@RunWith and is out of scope for the current parent."
+    },
+    {
+      "matchPackagePrefixes": ["com.liferay.portletmvc4spring:"],
+      "allowedVersions": "< 6.0",
+      "description": "Currently on portletmvc4spring 5.2.0 (Spring 4.3.x line). The 6.0.0-M1 milestone exists in Liferay's git but has not been published to Maven Central, and the upgrade requires Spring 6 + Jakarta EE + Java 17 — three migrations this portlet is not doing yet."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Encode existing review decisions as `packageRules` so renovate stops re-opening update PRs the portlet can't take. Same shape as the JasigWidgetPortlets rollout (see uPortal-Project/JasigWidgetPortlets#319).

**New rules:**

1. **`org.apache.portals.pluto:*` `< 3.0`** — Apache Pluto Attic; v3.x is `jakarta.portlet`. uPortal embedded Pluto has no jakarta path.
2. **`jaxen:jaxen` `< 2.0`** — Stay on Atlassian's `1.2.0-atlassian-2` fork (parent convention with commons-lang / ehcache-spring-annotations).
3. **`org.junit.jupiter:*` / `org.junit.platform:*` / `org.junit:junit-bom` `enabled: false`** — Project is JUnit 4.13.2 via parent.
4. **`com.liferay.portletmvc4spring:*` `< 6.0`** — 6.0.0-M1 not on Maven Central; upgrade is 3-stack (Spring 6 + Jakarta + Java 17).
5. **Extend existing JAXB rule** to include `com.sun.xml.bind:jaxb-xjc`.

## Test plan

- [ ] JSON syntax valid (verified locally with `python3 -c 'import json; json.load(open("renovate.json"))'`)
- [ ] After merge: forward-looking — when renovate next surfaces JUnit 5 / portletmvc4spring 6 / pluto-taglib 3 / jaxen 2 / jaxb-xjc 4 candidates, they don't open as PRs